### PR TITLE
EL7.3 compatibility

### DIFF
--- a/drivers/infiniband/ulp/srp/ib_srp.c
+++ b/drivers/infiniband/ulp/srp/ib_srp.c
@@ -3551,11 +3551,13 @@ static int srp_reset_host(struct scsi_cmnd *scmnd)
 
 static int srp_slave_alloc(struct scsi_device *sdev)
 {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 3, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 3, 0) || \
+	(!defined(RHEL_MAJOR) || RHEL_MAJOR -0 == 7 && RHEL_MINOR -0 >= 3)
 	struct Scsi_Host *shost = sdev->host;
 	struct srp_target_port *target = host_to_target(shost);
 	struct srp_device *srp_dev = target->srp_host->srp_dev;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 6, 0) && \
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 6, 0) || \
+	(!defined(RHEL_MAJOR) || RHEL_MAJOR -0 == 7 && RHEL_MINOR -0 >= 3)) && \
 	defined(HAVE_IB_DEVICE_SG_GAPS_REG)
 	struct ib_device *ibdev = srp_dev->dev;
 

--- a/drivers/infiniband/ulp/srp/ib_srp.c
+++ b/drivers/infiniband/ulp/srp/ib_srp.c
@@ -197,7 +197,8 @@ MODULE_PARM_DESC(ch_count,
 		 "Number of RDMA channels to use for communication with an SRP target. Using more than one channel improves performance if the HCA supports multiple completion vectors. The default value is the minimum of four times the number of online CPU sockets and the number of completion vectors supported by the HCA.");
 
 static void srp_add_one(struct ib_device *device);
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 3, 0)
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 3, 0)) && \
+	(!defined(RHEL_MAJOR) || RHEL_MAJOR -0 == 7 && RHEL_MINOR -0 < 3)
 static void srp_remove_one(struct ib_device *device);
 #else
 static void srp_remove_one(struct ib_device *device, void *client_data);
@@ -429,7 +430,8 @@ static int srp_new_rdma_cm_id(struct srp_rdma_ch *ch)
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3, 0, 0) && \
         (!defined(RHEL_MAJOR) || RHEL_MAJOR -0 < 6)
 	new_cm_id = rdma_create_id(srp_rdma_cm_handler, ch, RDMA_PS_TCP);
-#elif LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0)
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0) && \
+	(!defined(RHEL_MAJOR) || RHEL_MAJOR -0 == 7 && RHEL_MINOR -0 < 3)
 	new_cm_id = rdma_create_id(srp_rdma_cm_handler, ch, RDMA_PS_TCP,
 				   IB_QPT_RC);
 #else
@@ -500,7 +502,8 @@ static void srp_destroy_fr_pool(struct srp_fr_pool *pool)
 		return;
 
 	for (i = 0, d = &pool->desc[0]; i < pool->size; i++, d++) {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0) && \
+	(!defined(RHEL_MAJOR) || RHEL_MAJOR -0 == 7 && RHEL_MINOR -0 < 3)
 		if (d->frpl)
 			ib_free_fast_reg_page_list(d->frpl);
 #endif
@@ -516,7 +519,8 @@ static bool srp_gaps_supported(struct ib_device *device)
 #ifdef HAVE_IB_DEVICE_SG_GAPS_REG
 	struct ib_device_attr *attr;
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0) && \
+	(!defined(RHEL_MAJOR) || RHEL_MAJOR -0 == 7 && RHEL_MINOR -0 < 3)
 	attr = kmalloc(sizeof(*attr), GFP_KERNEL);
 	if (!attr)
 		goto out;
@@ -531,7 +535,8 @@ static bool srp_gaps_supported(struct ib_device *device)
 
 	gaps_supported = attr->device_cap_flags & IB_DEVICE_SG_GAPS_REG;
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0) && \
+	(!defined(RHEL_MAJOR) || RHEL_MAJOR -0 == 7 && RHEL_MINOR -0 < 3)
 free_attr:
 	kfree(attr);
 
@@ -555,7 +560,8 @@ static struct srp_fr_pool *srp_create_fr_pool(struct ib_device *device,
 	struct srp_fr_pool *pool;
 	struct srp_fr_desc *d;
 	struct ib_mr *mr;
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0) && \
+	(!defined(RHEL_MAJOR) || RHEL_MAJOR -0 == 7 && RHEL_MINOR -0 < 3)
 	struct ib_fast_reg_page_list *frpl;
 #endif
 	enum ib_mr_type mr_type = IB_MR_TYPE_MEM_REG;
@@ -588,7 +594,8 @@ static struct srp_fr_pool *srp_create_fr_pool(struct ib_device *device,
 			goto destroy_pool;
 		}
 		d->mr = mr;
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0) && \
+	(!defined(RHEL_MAJOR) || RHEL_MAJOR -0 == 7 && RHEL_MINOR -0 < 3)
 		frpl = ib_alloc_fast_reg_page_list(device, max_page_list_len);
 		if (IS_ERR(frpl)) {
 			ret = PTR_ERR(frpl);
@@ -1697,7 +1704,8 @@ reset_state:
 	return 0;
 }
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0) && \
+	(!defined(RHEL_MAJOR) || RHEL_MAJOR -0 == 7 && RHEL_MINOR -0 < 3)
 static int srp_map_finish_fr(struct srp_map_state *state,
 			     struct srp_rdma_ch *ch)
 {
@@ -1815,7 +1823,8 @@ static int srp_map_finish_fr(struct srp_map_state *state,
 	rkey = ib_inc_rkey(desc->mr->rkey);
 	ib_update_fast_reg_key(desc->mr, rkey);
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 7, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 7, 0) && \
+	(!defined(RHEL_MAJOR) || RHEL_MAJOR -0 == 7 && RHEL_MINOR -0 < 3)
 	n = ib_map_mr_sg(desc->mr, state->sg, sg_nents, dev->mr_page_size);
 #else
 	n = ib_map_mr_sg(desc->mr, state->sg, sg_nents, sg_offset_p,
@@ -1858,7 +1867,8 @@ static int srp_map_finish_fr(struct srp_map_state *state,
 }
 #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0) */
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0) && \
+	(!defined(RHEL_MAJOR) || RHEL_MAJOR -0 == 7 && RHEL_MINOR -0 < 3)
 static int srp_finish_mapping(struct srp_map_state *state,
 			      struct srp_rdma_ch *ch)
 {
@@ -1889,7 +1899,8 @@ static int srp_map_sg_entry(struct srp_map_state *state,
 
 		if (state->npages == dev->max_pages_per_mr ||
 		    (state->npages > 0 && offset != 0)) {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0) && \
+	(!defined(RHEL_MAJOR) || RHEL_MAJOR -0 == 7 && RHEL_MINOR -0 < 3)
 			ret = srp_finish_mapping(state, ch);
 #else
 			ret = srp_map_finish_fmr(state, ch);
@@ -1915,7 +1926,8 @@ static int srp_map_sg_entry(struct srp_map_state *state,
 	 */
 	ret = 0;
 	if ((dma_addr & ~dev->mr_page_mask) != 0)
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0) && \
+	(!defined(RHEL_MAJOR) || RHEL_MAJOR -0 == 7 && RHEL_MINOR -0 < 3)
 		ret = srp_finish_mapping(state, ch);
 #else
 		ret = srp_map_finish_fmr(state, ch);
@@ -1951,7 +1963,8 @@ static int srp_map_sg_fr(struct srp_map_state *state, struct srp_rdma_ch *ch,
 			 struct srp_request *req, struct scatterlist *scat,
 			 int count)
 {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0) && \
+	(!defined(RHEL_MAJOR) || RHEL_MAJOR -0 == 7 && RHEL_MINOR -0 < 3)
 	struct scatterlist *sg;
 	int i, ret;
 
@@ -2029,7 +2042,8 @@ static int srp_map_idb(struct srp_rdma_ch *ch, struct srp_request *req,
 	struct srp_map_state state;
 	struct srp_direct_buf idb_desc;
 	u64 idb_pages[1];
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0) || \
+	(!defined(RHEL_MAJOR) || RHEL_MAJOR -0 == 7 && RHEL_MINOR -0 >= 3)
 	struct scatterlist idb_sg[1];
 #endif
 	int ret;
@@ -2039,7 +2053,8 @@ static int srp_map_idb(struct srp_rdma_ch *ch, struct srp_request *req,
 	state.gen.next = next_mr;
 	state.gen.end = end_mr;
 	state.desc = &idb_desc;
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0) && \
+	(!defined(RHEL_MAJOR) || RHEL_MAJOR -0 == 7 && RHEL_MINOR -0 < 3)
 	state.pages = idb_pages;
 	state.pages[0] = (req->indirect_dma_addr &
 			  dev->mr_page_mask);
@@ -2048,7 +2063,8 @@ static int srp_map_idb(struct srp_rdma_ch *ch, struct srp_request *req,
 	state.base_dma_addr = req->indirect_dma_addr;
 	state.dma_len = idb_len;
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0) && \
+	(!defined(RHEL_MAJOR) || RHEL_MAJOR -0 == 7 && RHEL_MINOR -0 < 3)
 	ret = srp_finish_mapping(&state, ch);
 	if (ret < 0)
 		return ret;
@@ -4386,7 +4402,8 @@ static ssize_t srp_create_target(struct device *dev,
 	target->io_class	= SRP_REV16A_IB_IO_CLASS;
 	target->scsi_host	= target_host;
 	target->srp_host	= host;
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 3, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 3, 0) && \
+	(!defined(RHEL_MAJOR) || RHEL_MAJOR -0 == 7 && RHEL_MINOR -0 < 3)
 	target->lkey		= host->srp_dev->global_mr->lkey;
 #else
 	target->lkey		= host->srp_dev->pd->local_dma_lkey;
@@ -4767,7 +4784,8 @@ static void srp_add_one(struct ib_device *device)
 	u64 max_pages_per_mr;
 	unsigned int flags = 0;
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0) && \
+	(!defined(RHEL_MAJOR) || RHEL_MAJOR -0 == 7 && RHEL_MINOR -0 < 3)
 	attr = kmalloc(sizeof(*attr), GFP_KERNEL);
 	if (!attr)
 		return;
@@ -4881,14 +4899,16 @@ free_dev:
 	kfree(srp_dev);
 
 free_attr:
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0) && \
+	(!defined(RHEL_MAJOR) || RHEL_MAJOR -0 == 7 && RHEL_MINOR -0 < 3)
 	kfree(attr);
 #else
 	;
 #endif
 }
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 3, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 3, 0) && \
+	(!defined(RHEL_MAJOR) || RHEL_MAJOR -0 == 7 && RHEL_MINOR -0 < 3)
 static void srp_remove_one(struct ib_device *device)
 {
 	void *client_data = ib_get_client_data(device, &srp_client);

--- a/include/linux/backport.h
+++ b/include/linux/backport.h
@@ -302,7 +302,9 @@ static inline u8 rdma_end_port(const struct ib_device *device)
 }
 #endif
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 2, 0)
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 2, 0) &&  \
+	(!defined(RHEL_MAJOR) || RHEL_MAJOR -0 < 7 || \
+	 RHEL_MAJOR -0 == 7 && RHEL_MINOR -0 < 2))
 /* See also commit 569e247f7aa6 */
 enum ib_mr_type {
 	IB_MR_TYPE_MEM_REG,
@@ -423,11 +425,14 @@ struct rdma_cm_id *rdma_create_id_compat(rdma_cm_event_handler event_handler,
 #if (!defined(CONFIG_SUSE_KERNEL) &&				\
 	LINUX_VERSION_CODE < KERNEL_VERSION(4, 7, 0)) ||	\
 	LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0)
+
+#if 	(!defined(RHEL_MAJOR) || (RHEL_MAJOR -0 == 7 && RHEL_MINOR -0 < 3))
 enum scsi_scan_mode {
 	SCSI_SCAN_INITIAL = 0,
 	SCSI_SCAN_RESCAN,
 	SCSI_SCAN_MANUAL,
 };
+#endif
 #endif
 
 static inline void scsi_target_unblock_compat(struct device *dev,


### PR DESCRIPTION
I managed to *compile* this stuff, but it doesn't work.  I'm an end user.
```
[12215.431289] scsi host10: SRP.T10:24BE05FFFFB2A030
[12215.431630] ------------[ cut here ]------------
[12215.431642] WARNING: at /usr/src/ib_srp-backport/drivers/infiniband/ulp/srp/ib_srp.c:2804 srp_queuecommand+0xe98/0xf00 [ib_srp]()
[12215.431644] Modules linked in: ib_srp(OE) scsi_transport_srp(OE) rpcrdma ib_isert iscsi_target_mod target_core_mod ib_iser libiscsi scsi_transport_iscsi scsi_tgt ib_ipoib rdma_ucm ib_ucm ib_uverbs ib_umad rdma_cm ib_cm iw_cm mlx4_ib i
b_core binfmt_misc nf_conntrack_ipv4 nf_defrag_ipv4 ebtable_filter ebtables ip6table_filter ip6_tables xt_set ip_set_hash_ip ip_set nfnetlink xt_DSCP nf_conntrack_ftp nf_conntrack_irc xt_TCPMSS xt_owner xt_mac xt_length xt_ecn xt_LOG xt_
recent xt_limit xt_multiport xt_state xt_conntrack nf_conntrack ipt_ULOG ipt_REJECT nf_reject_ipv4 iptable_mangle iptable_filter bridge stp llc dm_raid raid456 async_raid6_recov async_memcpy async_pq raid6_pq libcrc32c async_xor xor asyn
c_tx vfat fat intel_powerclamp coretemp intel_rapl iosf_mbi kvm_intel kvm irqbypass crc32_pclmul ghash_clmulni_intel
[12215.431725]  aesni_intel lrw gf128mul glue_helper ablk_helper cryptd pcspkr ntb sg iTCO_wdt ipmi_ssif ipmi_devintf iTCO_vendor_support i2c_i801 mei_me shpchp sb_edac mei lpc_ich ipmi_si edac_core ioatdma ipmi_msghandler wmi nfsd auth_
rpcgss nfs_acl lockd grace sunrpc ip_tables ext4 mbcache jbd2 mlx4_en raid1 sd_mod crc_t10dif crct10dif_generic mgag200 crct10dif_pclmul drm_kms_helper crct10dif_common crc32c_intel syscopyarea sysfillrect sysimgblt mpt3sas fb_sys_fops i
sci ahci ttm igb libahci libsas raid_class mlx4_core drm scsi_transport_sas ptp pps_core libata dca i2c_algo_bit i2c_core devlink fjes dm_mirror dm_region_hash dm_log dm_mod btier(OE) [last unloaded: scsi_transport_srp]
[12215.431795] CPU: 17 PID: 15085 Comm: srp_daemon Tainted: G        W  OE  ------------   3.10.0-514.6.1.el7.x86_64 #1
[12215.431798] Hardware name: Supermicro X9DRT-PIBF/X9DRT-PIBF, BIOS 3.2 07/07/2015
[12215.431800]  0000000000000000 00000000e9add327 ffff88006eacb810 ffffffff816862ac
[12215.431805]  ffff88006eacb848 ffffffff81085940 0000000000000000 ffff880071f5a300
[12215.431809]  ffff880023676000 ffff88001357c848 ffff880013a8d680 ffff88006eacb858
[12215.431814] Call Trace:
[12215.431823]  [<ffffffff816862ac>] dump_stack+0x19/0x1b
[12215.431829]  [<ffffffff81085940>] warn_slowpath_common+0x70/0xb0
[12215.431833]  [<ffffffff81085a8a>] warn_slowpath_null+0x1a/0x20
[12215.431839]  [<ffffffffa09c8848>] srp_queuecommand+0xe98/0xf00 [ib_srp]
[12215.431845]  [<ffffffff8109684b>] ? __internal_add_timer+0xab/0x130
[12215.431850]  [<ffffffff81096902>] ? internal_add_timer+0x32/0x70
[12215.431854]  [<ffffffff81098eeb>] ? mod_timer+0x14b/0x230
[12215.431861]  [<ffffffff81451b0a>] scsi_dispatch_cmd+0xaa/0x230
[12215.431866]  [<ffffffff8145ac11>] scsi_request_fn+0x501/0x770
[12215.431874]  [<ffffffff81183899>] ? mempool_alloc+0x69/0x170
[12215.431882]  [<ffffffff812eb1a3>] __blk_run_queue+0x33/0x40
[12215.431887]  [<ffffffff812f43e5>] blk_execute_rq_nowait+0xb5/0x180
[12215.431892]  [<ffffffff812f453b>] blk_execute_rq+0x8b/0x150
[12215.431898]  [<ffffffff81236759>] ? bio_phys_segments+0x19/0x20
[12215.431902]  [<ffffffff812efe28>] ? blk_rq_bio_prep+0x68/0xc0
[12215.431907]  [<ffffffff812f4259>] ? blk_rq_map_kern+0xb9/0x160
[12215.431911]  [<ffffffff81457983>] scsi_execute+0xd3/0x170
[12215.431916]  [<ffffffff814592ce>] scsi_execute_req_flags+0x8e/0x100
[12215.431922]  [<ffffffff8145ca33>] scsi_probe_and_add_lun+0x243/0xe30
[12215.431928]  [<ffffffff8143802c>] ? __pm_runtime_resume+0x5c/0x80
[12215.431933]  [<ffffffff8145e005>] __scsi_scan_target+0x105/0x260
[12215.431938]  [<ffffffff8145e278>] scsi_scan_target+0x118/0x130
[12215.431944]  [<ffffffffa09ca775>] srp_create_target+0x12f5/0x17d0 [ib_srp]
[12215.431950]  [<ffffffff811cf25a>] ? alloc_pages_current+0xaa/0x170
[12215.431957]  [<ffffffff814271a8>] dev_attr_store+0x18/0x30
[12215.431963]  [<ffffffff8127b736>] sysfs_write_file+0xc6/0x140
[12215.431967]  [<ffffffff811fe27d>] vfs_write+0xbd/0x1e0
[12215.431972]  [<ffffffff8120ec9d>] ? putname+0x3d/0x60
[12215.431976]  [<ffffffff811fed9f>] SyS_write+0x7f/0xe0
[12215.431983]  [<ffffffff816968c9>] system_call_fastpath+0x16/0x1b
[12215.431986] ---[ end trace b10dd9225de1482f ]---
[12215.431988] ------------[ cut here ]------------
[12215.431993] WARNING: at /usr/src/ib_srp-backport/drivers/infiniband/ulp/srp/ib_srp.c:2810 srp_queuecommand+0xef1/0xf00 [ib_srp]()
[12215.431996] host10: tag 0xffff: idx 65535 >= 63
[12215.431998] Modules linked in: ib_srp(OE) scsi_transport_srp(OE) rpcrdma ib_isert iscsi_target_mod target_core_mod ib_iser libiscsi scsi_transport_iscsi scsi_tgt ib_ipoib rdma_ucm ib_ucm ib_uverbs ib_umad rdma_cm ib_cm iw_cm mlx4_ib ib_core binfmt_misc nf_conntrack_ipv4 nf_defrag_ipv4 ebtable_filter ebtables ip6table_filter ip6_tables xt_set ip_set_hash_ip ip_set nfnetlink xt_DSCP nf_conntrack_ftp nf_conntrack_irc xt_TCPMSS xt_owner xt_mac xt_length xt_ecn xt_LOG xt_recent xt_limit xt_multiport xt_state xt_conntrack nf_conntrack ipt_ULOG ipt_REJECT nf_reject_ipv4 iptable_mangle iptable_filter bridge stp llc dm_raid raid456 async_raid6_recov async_memcpy async_pq raid6_pq libcrc32c async_xor xor async_tx vfat fat intel_powerclamp coretemp intel_rapl iosf_mbi kvm_intel kvm irqbypass crc32_pclmul ghash_clmulni_intel
[12215.432051]  aesni_intel lrw gf128mul glue_helper ablk_helper cryptd pcspkr ntb sg iTCO_wdt ipmi_ssif ipmi_devintf iTCO_vendor_support i2c_i801 mei_me shpchp sb_edac mei lpc_ich ipmi_si edac_core ioatdma ipmi_msghandler wmi nfsd auth_rpcgss nfs_acl lockd grace sunrpc ip_tables ext4 mbcache jbd2 mlx4_en raid1 sd_mod crc_t10dif crct10dif_generic mgag200 crct10dif_pclmul drm_kms_helper crct10dif_common crc32c_intel syscopyarea sysfillrect sysimgblt mpt3sas fb_sys_fops isci ahci ttm igb libahci libsas raid_class mlx4_core drm scsi_transport_sas ptp pps_core libata dca i2c_algo_bit i2c_core devlink fjes dm_mirror dm_region_hash dm_log dm_mod btier(OE) [last unloaded: scsi_transport_srp]
[12215.432104] CPU: 17 PID: 15085 Comm: srp_daemon Tainted: G        W  OE  ------------   3.10.0-514.6.1.el7.x86_64 #1
[12215.432107] Hardware name: Supermicro X9DRT-PIBF/X9DRT-PIBF, BIOS 3.2 07/07/2015
[12215.432108]  ffff88006eacb800 00000000e9add327 ffff88006eacb7b8 ffffffff816862ac
[12215.432112]  ffff88006eacb7f0 ffffffff81085940 ffff880071868000 ffff880071f5a300
[12215.432116]  000000000000ffff 000000000000ffff ffff880013a8d680 ffff88006eacb858
[12215.432120] Call Trace:
[12215.432124]  [<ffffffff816862ac>] dump_stack+0x19/0x1b
[12215.432127]  [<ffffffff81085940>] warn_slowpath_common+0x70/0xb0
[12215.432131]  [<ffffffff810859dc>] warn_slowpath_fmt+0x5c/0x80
[12215.432136]  [<ffffffffa09c88a1>] srp_queuecommand+0xef1/0xf00 [ib_srp]
[12215.432141]  [<ffffffff8109684b>] ? __internal_add_timer+0xab/0x130
[12215.432145]  [<ffffffff81096902>] ? internal_add_timer+0x32/0x70
[12215.432150]  [<ffffffff81098eeb>] ? mod_timer+0x14b/0x230
[12215.432154]  [<ffffffff81451b0a>] scsi_dispatch_cmd+0xaa/0x230
[12215.432158]  [<ffffffff8145ac11>] scsi_request_fn+0x501/0x770
[12215.432163]  [<ffffffff81183899>] ? mempool_alloc+0x69/0x170
[12215.432168]  [<ffffffff812eb1a3>] __blk_run_queue+0x33/0x40
[12215.432173]  [<ffffffff812f43e5>] blk_execute_rq_nowait+0xb5/0x180
[12215.432178]  [<ffffffff812f453b>] blk_execute_rq+0x8b/0x150
[12215.432182]  [<ffffffff81236759>] ? bio_phys_segments+0x19/0x20
[12215.432185]  [<ffffffff812efe28>] ? blk_rq_bio_prep+0x68/0xc0
[12215.432190]  [<ffffffff812f4259>] ? blk_rq_map_kern+0xb9/0x160
[12215.432194]  [<ffffffff81457983>] scsi_execute+0xd3/0x170
[12215.432199]  [<ffffffff814592ce>] scsi_execute_req_flags+0x8e/0x100
[12215.432204]  [<ffffffff8145ca33>] scsi_probe_and_add_lun+0x243/0xe30
[12215.432209]  [<ffffffff8143802c>] ? __pm_runtime_resume+0x5c/0x80
[12215.432214]  [<ffffffff8145e005>] __scsi_scan_target+0x105/0x260
[12215.432219]  [<ffffffff8145e278>] scsi_scan_target+0x118/0x130
[12215.432224]  [<ffffffffa09ca775>] srp_create_target+0x12f5/0x17d0 [ib_srp]
[12215.432229]  [<ffffffff811cf25a>] ? alloc_pages_current+0xaa/0x170
[12215.432233]  [<ffffffff814271a8>] dev_attr_store+0x18/0x30
[12215.432238]  [<ffffffff8127b736>] sysfs_write_file+0xc6/0x140
[12215.432241]  [<ffffffff811fe27d>] vfs_write+0xbd/0x1e0
[12215.432244]  [<ffffffff8120ec9d>] ? putname+0x3d/0x60
[12215.432248]  [<ffffffff811fed9f>] SyS_write+0x7f/0xe0
[12215.432253]  [<ffffffff816968c9>] system_call_fastpath+0x16/0x1b
[12215.432255] ---[ end trace b10dd9225de14830 ]---
[12215.858979] scsi host10: Null scmnd for RSP w/tag 0x0000000000ffff received on ch 0 / QP 0x216
[12236.441212] scsi host10: SRP abort called
[12236.445275] scsi host10: Sending SRP abort for tag 0xffff
[12236.503132] scsi host10: ib_srp: new target: id_ext 24be05ffffb2a030 ioc_guid 24be05ffffb2a030 pkey ffff service_id 24be05ffffb2a030 sgid fe80:0000:0000:0000:0025:90ff:ffdf:ac89 dgid fe80:0000:0000:0000:0002:c903:00fb:9c31
```